### PR TITLE
Get the cluster running on OSX

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis-cluster:
-    network_mode: host
+    network_mode: bridge
     build:
       context: .
       args:

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$1" = 'redis-cluster' ]; then
     sleep 3
 
     IP="127.0.0.1"
-    echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 0 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003
+    echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 0 ${IP}:7001 ${IP}:7002 ${IP}:7003
     tail -f /var/log/supervisor/redis*.log
 else
   exec "$@"


### PR DESCRIPTION
Mac port fix and removing the unused port from the redis create command which caused the service to not start correctly.